### PR TITLE
fix: Reduce compressor aggression for responsive volume control

### DIFF
--- a/initial/BeatBox_Pro_Minimal.html
+++ b/initial/BeatBox_Pro_Minimal.html
@@ -2476,11 +2476,11 @@
         audioCtx = new (window.AudioContext || window.webkitAudioContext)();
         
         compressor = audioCtx.createDynamicsCompressor();
-        compressor.threshold.value = -24;
-        compressor.knee.value = 30;
-        compressor.ratio.value = 12;
-        compressor.attack.value = 0.003;
-        compressor.release.value = 0.25;
+        compressor.threshold.value = -6;    // Only compress loud peaks
+        compressor.knee.value = 10;         // Gentler knee
+        compressor.ratio.value = 4;         // 4:1 is standard "soft limiting"
+        compressor.attack.value = 0.01;     // Slightly slower attack
+        compressor.release.value = 0.1;     // Faster release for more punch
         
         masterGain = audioCtx.createGain();
         masterGain.gain.value = 0.9;


### PR DESCRIPTION
Updated master compressor settings to allow volume slider changes to be more noticeable:
- threshold: -24dB → -6dB (only compress loud peaks)
- knee: 30 → 10 (gentler knee)
- ratio: 12:1 → 4:1 (standard soft limiting)
- attack: 3ms → 10ms (slightly slower attack)
- release: 250ms → 100ms (faster release for more punch)

This prevents the compressor from squashing user volume adjustments while still protecting against clipping.

Fixes #17